### PR TITLE
Fix TGA RLE read buffer overflow and add EOF error detection (CVE-2021-36489)

### DIFF
--- a/src/pcx.c
+++ b/src/pcx.c
@@ -124,10 +124,21 @@ BITMAP *load_pcx_pf(PACKFILE *f, RGB *pal)
 #endif
 
       while (x < bytes_per_line*bpp/8) {
-	 ch = pack_getc(f);
+	 c = pack_getc(f);
+	 if (c == EOF) {
+	    destroy_bitmap(b);
+	    return NULL;
+	 }
+	 ch = c;
 	 if ((ch & 0xC0) == 0xC0) {
-	    c = (ch & 0x3F);
-	    ch = pack_getc(f);
+	    int run_count = (ch & 0x3F);
+	    c = pack_getc(f);
+	    if (c == EOF) {
+	       destroy_bitmap(b);
+	       return NULL;
+	    }
+	    ch = c;
+	    c = run_count;
 	 }
 	 else
 	    c = 1;

--- a/src/tga.c
+++ b/src/tga.c
@@ -126,6 +126,8 @@ static unsigned int *rle_tga_read32(unsigned int *b, int w, PACKFILE *f)
 	    count = w - c;
 	 c += count;
 	 color = single_tga_read32(f);
+	 if (pack_feof(f))
+	    return NULL;
 	 while (count--)
 	    *b++ = color;
       }
@@ -196,6 +198,8 @@ static unsigned char *rle_tga_read24(unsigned char *b, int w, PACKFILE *f)
 	    count = w - c;
 	 c += count;
 	 color = single_tga_read24(f);
+	 if (pack_feof(f))
+	    return NULL;
 	 while (count--) {
 	    WRITE3BYTES(b, color);
 	    b += 3;
@@ -265,6 +269,8 @@ static unsigned short *rle_tga_read16(unsigned short *b, int w, PACKFILE *f)
 	    count = w - c;
 	 c += count;
 	 color = single_tga_read16(f);
+	 if (pack_feof(f))
+	    return NULL;
 	 while (count--)
 	    *b++ = color;
       }

--- a/src/tga.c
+++ b/src/tga.c
@@ -68,6 +68,8 @@ static unsigned char *rle_tga_read8(unsigned char *b, int w, PACKFILE *f)
 	    count = w - c;
 	 c += count;
 	 b = raw_tga_read8(b, count, f);
+	 if (pack_feof(f))
+	    return NULL;
       }
    } while (c < w);
 
@@ -138,6 +140,8 @@ static unsigned int *rle_tga_read32(unsigned int *b, int w, PACKFILE *f)
 	    count = w - c;
 	 c += count;
 	 b = raw_tga_read32(b, count, f);
+	 if (pack_feof(f))
+	    return NULL;
       }
    } while (c < w);
 
@@ -212,6 +216,8 @@ static unsigned char *rle_tga_read24(unsigned char *b, int w, PACKFILE *f)
 	    count = w - c;
 	 c += count;
 	 b = raw_tga_read24(b, count, f);
+	 if (pack_feof(f))
+	    return NULL;
       }
    } while (c < w);
 
@@ -281,6 +287,8 @@ static unsigned short *rle_tga_read16(unsigned short *b, int w, PACKFILE *f)
 	    count = w - c;
 	 c += count;
 	 b = raw_tga_read16(b, count, f);
+	 if (pack_feof(f))
+	    return NULL;
       }
    } while (c < w);
 

--- a/src/tga.c
+++ b/src/tga.c
@@ -39,28 +39,39 @@ static INLINE unsigned char *raw_tga_read8(unsigned char *b, int w, PACKFILE *f)
 
 /* rle_tga_read8:
  *  Helper for reading 256-color RLE data from TGA files.
+ *  Returns pointer past last written byte, or NULL on error.
  */
-static void rle_tga_read8(unsigned char *b, int w, PACKFILE *f)
+static unsigned char *rle_tga_read8(unsigned char *b, int w, PACKFILE *f)
 {
    int value, count, c = 0;
 
    do {
       count = pack_getc(f);
+      if (count == EOF)
+	 return NULL;
       if (count & 0x80) {
 	 /* run-length packet */
 	 count = (count & 0x7F) + 1;
+	 if (c + count > w)
+	    count = w - c;
 	 c += count;
 	 value = pack_getc(f);
+	 if (value == EOF)
+	    return NULL;
 	 while (count--)
 	    *b++ = value;
       }
       else {
 	 /* raw packet */
 	 count++;
+	 if (c + count > w)
+	    count = w - c;
 	 c += count;
 	 b = raw_tga_read8(b, count, f);
       }
    } while (c < w);
+
+   return b;
 }
 
 
@@ -98,16 +109,21 @@ static unsigned int *raw_tga_read32(unsigned int *b, int w, PACKFILE *f)
 
 /* rle_tga_read32:
  *  Helper for reading 32-bit RLE data from TGA files.
+ *  Returns pointer past last written element, or NULL on error.
  */
-static void rle_tga_read32(unsigned int *b, int w, PACKFILE *f)
+static unsigned int *rle_tga_read32(unsigned int *b, int w, PACKFILE *f)
 {
    int color, count, c = 0;
 
    do {
       count = pack_getc(f);
+      if (count == EOF)
+	 return NULL;
       if (count & 0x80) {
 	 /* run-length packet */
 	 count = (count & 0x7F) + 1;
+	 if (c + count > w)
+	    count = w - c;
 	 c += count;
 	 color = single_tga_read32(f);
 	 while (count--)
@@ -116,10 +132,14 @@ static void rle_tga_read32(unsigned int *b, int w, PACKFILE *f)
       else {
 	 /* raw packet */
 	 count++;
+	 if (c + count > w)
+	    count = w - c;
 	 c += count;
 	 b = raw_tga_read32(b, count, f);
       }
    } while (c < w);
+
+   return b;
 }
 
 
@@ -159,16 +179,21 @@ static unsigned char *raw_tga_read24(unsigned char *b, int w, PACKFILE *f)
 
 /* rle_tga_read24:
  *  Helper for reading 24-bit RLE data from TGA files.
+ *  Returns pointer past last written byte, or NULL on error.
  */
-static void rle_tga_read24(unsigned char *b, int w, PACKFILE *f)
+static unsigned char *rle_tga_read24(unsigned char *b, int w, PACKFILE *f)
 {
    int color, count, c = 0;
 
    do {
       count = pack_getc(f);
+      if (count == EOF)
+	 return NULL;
       if (count & 0x80) {
 	 /* run-length packet */
 	 count = (count & 0x7F) + 1;
+	 if (c + count > w)
+	    count = w - c;
 	 c += count;
 	 color = single_tga_read24(f);
 	 while (count--) {
@@ -179,10 +204,14 @@ static void rle_tga_read24(unsigned char *b, int w, PACKFILE *f)
       else {
 	 /* raw packet */
 	 count++;
+	 if (c + count > w)
+	    count = w - c;
 	 c += count;
 	 b = raw_tga_read24(b, count, f);
       }
    } while (c < w);
+
+   return b;
 }
 
 
@@ -195,6 +224,7 @@ static INLINE int single_tga_read16(PACKFILE *f)
    int value;
 
    value = pack_igetw(f);
+   value &= 0x7FFF; /* mask out 1-bit alpha value */
 
    return (((value >> 10) & 0x1F) << _rgb_r_shift_15) |
 	  (((value >> 5) & 0x1F) << _rgb_g_shift_15)  |
@@ -218,16 +248,21 @@ static unsigned short *raw_tga_read16(unsigned short *b, int w, PACKFILE *f)
 
 /* rle_tga_read16:
  *  Helper for reading 16-bit RLE data from TGA files.
+ *  Returns pointer past last written element, or NULL on error.
  */
-static void rle_tga_read16(unsigned short *b, int w, PACKFILE *f)
+static unsigned short *rle_tga_read16(unsigned short *b, int w, PACKFILE *f)
 {
    int color, count, c = 0;
 
    do {
       count = pack_getc(f);
+      if (count == EOF)
+	 return NULL;
       if (count & 0x80) {
 	 /* run-length packet */
 	 count = (count & 0x7F) + 1;
+	 if (c + count > w)
+	    count = w - c;
 	 c += count;
 	 color = single_tga_read16(f);
 	 while (count--)
@@ -236,10 +271,14 @@ static void rle_tga_read16(unsigned short *b, int w, PACKFILE *f)
       else {
 	 /* raw packet */
 	 count++;
+	 if (c + count > w)
+	    count = w - c;
 	 c += count;
 	 b = raw_tga_read16(b, count, f);
       }
    } while (c < w);
+
+   return b;
 }
 
 
@@ -419,28 +458,44 @@ BITMAP *load_tga_pf(PACKFILE *f, RGB *pal)
 
 	 case 1:
 	 case 3:
-	    if (compressed)
-	       rle_tga_read8(bmp->line[yc], image_width, f);
+	    if (compressed) {
+	       if (!rle_tga_read8(bmp->line[yc], image_width, f)) {
+		  destroy_bitmap(bmp);
+		  return NULL;
+	       }
+	    }
 	    else
 	       raw_tga_read8(bmp->line[yc], image_width, f);
 	    break;
 
 	 case 2:
 	    if (bpp == 32) {
-	       if (compressed)
-		  rle_tga_read32((unsigned int *)bmp->line[yc], image_width, f);
+	       if (compressed) {
+		  if (!rle_tga_read32((unsigned int *)bmp->line[yc], image_width, f)) {
+		     destroy_bitmap(bmp);
+		     return NULL;
+		  }
+	       }
 	       else
 		  raw_tga_read32((unsigned int *)bmp->line[yc], image_width, f);
 	    }
 	    else if (bpp == 24) {
-	       if (compressed)
-		  rle_tga_read24(bmp->line[yc], image_width, f);
+	       if (compressed) {
+		  if (!rle_tga_read24(bmp->line[yc], image_width, f)) {
+		     destroy_bitmap(bmp);
+		     return NULL;
+		  }
+	       }
 	       else
 		  raw_tga_read24(bmp->line[yc], image_width, f);
 	    }
 	    else {
-	       if (compressed)
-		  rle_tga_read16((unsigned short *)bmp->line[yc], image_width, f);
+	       if (compressed) {
+		  if (!rle_tga_read16((unsigned short *)bmp->line[yc], image_width, f)) {
+		     destroy_bitmap(bmp);
+		     return NULL;
+		  }
+	       }
 	       else
 		  raw_tga_read16((unsigned short *)bmp->line[yc], image_width, f);
 	    }


### PR DESCRIPTION
This is provided by co-pilot - I can provide the full co-pilot business if required.

```
Fix TGA RLE read buffer overflow and add EOF error detection
- Modify rle_tga_read8, rle_tga_read16, rle_tga_read24, rle_tga_read32 to return pointer (or NULL on error)
- Add EOF detection for packet header and value fields in all RLE routines
- Clamp packet lengths to prevent buffer overflow past scanline width (w)
- Mask out 1-bit alpha value in single_tga_read16 (value &= 0x7FFF)
- Update load_tga_pf to check for NULL returns and cleanup/abort on error

Fixes: Debian #1032670
Reference: liballeg/allegro5#1253
Reference: liballeg/allegro5@2c712d4

Add EOF checks after reading color values in RLE routines
Use pack_feof() to detect EOF after single_tga_read32/24/16 calls
in the run-length packet handling code.

Add EOF checks after raw packet reads in RLE routines
Use pack_feof() to detect EOF after raw_tga_read* calls in the
raw packet handling code paths for all RLE routines.

Add EOF error detection to PCX RLE decode
Add EOF checks in the PCX RLE decode loop to prevent issues when
loading truncated or malformed PCX files. Similar to the TGA fixes,
this properly detects end-of-file conditions and returns NULL with
proper cleanup.
```

See https://security-tracker.debian.org/tracker/CVE-2021-36489

