### PR TITLE
Fix the pack_feof usage in the previous two commits.

### DIFF
--- a/src/pcx.c
+++ b/src/pcx.c
@@ -124,18 +124,18 @@ BITMAP *load_pcx_pf(PACKFILE *f, RGB *pal)
 #endif
 
       while (x < bytes_per_line*bpp/8) {
-	 ch = pack_getc(f);
 	 if (pack_feof(f)) {
 	    destroy_bitmap(b);
 	    return NULL;
          }
+	 ch = pack_getc(f);
 	 if ((ch & 0xC0) == 0xC0) {
 	    c = (ch & 0x3F);
-	    ch = pack_getc(f);
 	    if (pack_feof(f)) {
 	       destroy_bitmap(b);
 	       return NULL;
 	    }
+	    ch = pack_getc(f);
 	 }
 	 else
 	    c = 1;

--- a/src/tga.c
+++ b/src/tga.c
@@ -66,9 +66,9 @@ static unsigned char *rle_tga_read8(unsigned char *b, int w, PACKFILE *f)
 	 c += count;
          if (c > w)
             return NULL;
-	 b = raw_tga_read8(b, count, f);
          if (pack_feof(f))
 	    return NULL;
+	 b = raw_tga_read8(b, count, f);
       }
    } while (c < w);
    return b;
@@ -124,9 +124,9 @@ static unsigned int *rle_tga_read32(unsigned int *b, int w, PACKFILE *f)
 	 c += count;
          if (c > w)
             return NULL;
-	 color = single_tga_read32(f);
 	 if (pack_feof(f))
 	    return NULL;
+	 color = single_tga_read32(f);
 	 while (count--)
 	    *b++ = color;
       }
@@ -136,9 +136,9 @@ static unsigned int *rle_tga_read32(unsigned int *b, int w, PACKFILE *f)
 	 c += count;
          if (c > w)
             return NULL;
-	 b = raw_tga_read32(b, count, f);
 	 if (pack_feof(f))
 	    return NULL;
+	 b = raw_tga_read32(b, count, f);
       }
    } while (c < w);
    return b;
@@ -210,9 +210,9 @@ static unsigned char *rle_tga_read24(unsigned char *b, int w, PACKFILE *f)
 	 c += count;
          if (c > w)
             return NULL;
-	 b = raw_tga_read24(b, count, f);
 	 if (pack_feof(f))
 	    return NULL;
+	 b = raw_tga_read24(b, count, f);
       }
    } while (c < w);
    return b;
@@ -267,9 +267,9 @@ static unsigned short *rle_tga_read16(unsigned short *b, int w, PACKFILE *f)
 	 c += count;
          if (c > w)
             return NULL;
-	 color = single_tga_read16(f);
 	 if (pack_feof(f))
 	    return NULL;
+	 color = single_tga_read16(f);
 	 while (count--)
 	    *b++ = color;
       }
@@ -279,9 +279,9 @@ static unsigned short *rle_tga_read16(unsigned short *b, int w, PACKFILE *f)
 	 c += count;
          if (c > w)
             return NULL;
-	 b = raw_tga_read16(b, count, f);
 	 if (pack_feof(f))
 	    return NULL;
+	 b = raw_tga_read16(b, count, f);
       }
    } while (c < w);
    return b;


### PR DESCRIPTION
pack_feof, unlike feof (and the related al_feof from Allegro 5) does NOT require you to read past the end of file to start returning true!

So, any check of pack_feof after a read is wrong, as it triggers on valid reads at the legitimate end of file.

In this commit, what we do is simple check pack_feof before reads. We understand that for multi-byte reads this does not quite catch all the problems, but in many ways it never *really* mattered that we placed EOF bytes into the decoded TGA bitmaps, so it don't matter what we do here.